### PR TITLE
refactor: mixin improvement and event bus handler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,4 +129,9 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',
     ],
+    entry_points={
+        "lms.djangoapp": [
+            "skill_tagging = skill_tagging.apps:SkillTaggingConfig",
+        ],
+    },
 )

--- a/skill_tagging/apps.py
+++ b/skill_tagging/apps.py
@@ -11,3 +11,17 @@ class SkillTaggingConfig(AppConfig):
     """
 
     name = 'skill_tagging'
+
+    plugin_app = {
+        "signals_config": {
+            "lms.djangoapp": {
+                "relative_path": "handlers",
+                "receivers": [
+                    {
+                        "receiver_func_name": "listen_for_xblock_skill_verified",
+                        "signal_path": "openedx_events.learning.signals.XBLOCK_SKILL_VERIFIED",
+                    },
+                ],
+            }
+        },
+    }

--- a/skill_tagging/handlers.py
+++ b/skill_tagging/handlers.py
@@ -1,0 +1,19 @@
+"""
+skill_tagging signal handlers
+"""
+
+from openedx_events.event_bus import get_producer
+from openedx_events.learning.signals import XBLOCK_SKILL_VERIFIED
+
+
+def listen_for_xblock_skill_verified(**kwargs):
+    """
+    Publish openedx-event XBLOCK_SKILL_VERIFIED signal onto the event bus.
+    """
+    get_producer().send(
+        signal=XBLOCK_SKILL_VERIFIED,
+        topic='xblock-skill-verified',
+        event_key_field='xblock_info.usage_key',
+        event_data={'xblock_info': kwargs['xblock_info']},
+        event_metadata=kwargs['metadata'],
+    )

--- a/skill_tagging/pipeline.py
+++ b/skill_tagging/pipeline.py
@@ -115,9 +115,12 @@ class AddVideoBlockSkillVerificationComponent(VerificationPipelineBase, Pipeline
     """
     def run_filter(self, block, context):  # pylint: disable=arguments-differ
         """Pipeline Step implementing the Filter"""
-        skills = self.fetch_related_skills(block)
         usage_id = block.scope_ids.usage_id
-        if not skills or not self.should_run_filter() or usage_id.block_type != "video":
+        if usage_id.block_type != "video":
+            # avoid fetching skills for other xblocks
+            return {"block": block, "context": context}
+        skills = self.fetch_related_skills(block)
+        if not skills or not self.should_run_filter():
             return {"block": block, "context": context}
         data = self.get_skill_context(usage_id, block, skills)
 

--- a/skill_tagging/skill_tagging_mixin.py
+++ b/skill_tagging/skill_tagging_mixin.py
@@ -12,6 +12,7 @@ from openedx_events.learning.data import XBlockSkillVerificationData
 from openedx_events.learning.signals import XBLOCK_SKILL_VERIFIED
 from xblock.core import XBlock
 from xblock.fields import Boolean, Scope
+from xblock.runtime import NoSuchServiceError
 
 from .utils import get_api_client
 
@@ -35,6 +36,16 @@ class SkillTaggingMixin:
         scope=Scope.user_state
     )
 
+    def _get_user_service(self):
+        """
+        Tries to get user service, if not found returns None.
+        """
+        try:
+            user_service = self.runtime.service(self, 'user')
+        except NoSuchServiceError:
+            user_service = None
+        return user_service
+
     def fetch_skill_tags(self):
         """
         Fetch skill tags for the XBlock by calling taxonomy api.
@@ -45,7 +56,7 @@ class SkillTaggingMixin:
             )
             return []
 
-        user_service = self.runtime.service(self, 'user')
+        user_service = self._get_user_service()
         if not user_service:
             LOGGER.info(
                 "No user service available for this xblock. Cannot proceed."


### PR DESCRIPTION
**Description:** 

- Adds additional check before fetching skills for block avoiding unnecessary calls to discovery service. 
- Also fixes catches exception when no user service is found in block.
- Updates app config and setup.py to trigger handlers for openedx-events
- Finally adds a handler to take `XBLOCK_SKILL_VERIFIED` signal and push it to event_bus.

**Testing instructions:**

**Locally:**

1. Follow instructions in https://github.com/open-craft/xblock-skill-tagging/pull/4
2. Open discovery-logs by using `make discovery-logs`
3. Refresh page and see multiple calls to discovery in logs for all types of blocks
4. Checkout this MR and the calls should only be made for video xblocks

**Sandbox:**
- URL: https://app.skilltagging.opencraft.hosting/learning/course/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@sequential+block@19a30717eff543078a5d94ae9d6c18a5/block-v1:edX+DemoX+Demo_Course+type@vertical+block@4f6c1b4e316a419ab5b6bf30e6c708e9
- Login with staff credentials
- Play video (skip to end), the form will be displayed when the video ends.
- ssh into above app server
- tail logs using `sudo tail -100f /edx/var/log/supervisor/lms-stderr.log`
- I have added some logs which will log the skills when it is fetched
- Skills should only be fetched for video xblocks.


**Reviewers:**
- [ ] @pkulkark 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
