### PR TITLE
refactor: tweak verification form styles

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,6 +3,5 @@
 
 Django             # Web application framework
 django-model-utils        # Provides TimeStampedModel abstract base class
-# TODO: update below dependencies when its commits are merged to upstream
-git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba#egg=openedx_events
-git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a#egg=openedx-filters
+openedx_events
+openedx-filters

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,4 +5,4 @@ Django             # Web application framework
 django-model-utils        # Provides TimeStampedModel abstract base class
 # TODO: update below dependencies when its commits are merged to upstream
 git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba#egg=openedx_events
-git+https://github.com/open-craft/openedx-filters.git@d0206cf84f2e5e22b1a99d06566d88839d40b9fe#egg=openedx-filters
+git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a#egg=openedx-filters

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,9 +21,9 @@ edx-opaque-keys[django]==2.3.0
     # via openedx-events
 fastavro==1.7.1
     # via openedx-events
-openedx_events @ git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba
+openedx-events==5.1.0
     # via -r requirements/base.in
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
+openedx-filters==1.1.0
     # via -r requirements/base.in
 pbr==5.11.1
     # via stevedore

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via django
 attrs==22.2.0
     # via openedx-events
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -19,19 +19,19 @@ django-model-utils==4.3.1
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via openedx-events
-fastavro==1.7.0
+fastavro==1.7.1
     # via openedx-events
 openedx_events @ git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba
     # via -r requirements/base.in
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@d0206cf84f2e5e22b1a99d06566d88839d40b9fe
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
     # via -r requirements/base.in
-pbr==5.11.0
+pbr==5.11.1
     # via stevedore
 pymongo==3.13.0
     # via edx-opaque-keys
-pytz==2022.7
+pytz==2022.7.1
     # via django
 sqlparse==0.4.3
     # via django
-stevedore==4.1.1
+stevedore==5.0.0
     # via edx-opaque-keys

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,11 +6,11 @@
 #
 certifi==2022.12.7
     # via requests
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==7.0.1
+coverage==7.1.0
     # via codecov
 distlib==0.3.6
     # via virtualenv
@@ -20,15 +20,15 @@ filelock==3.9.0
     #   virtualenv
 idna==3.4
     # via requests
-packaging==22.0
+packaging==23.0
     # via tox
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.1
+requests==2.28.2
     # via codecov
 six==1.16.0
     # via tox
@@ -41,7 +41,7 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,11 +34,11 @@ boto==2.49.0
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
-boto3==1.26.72
+boto3==1.26.74
     # via
     #   -r requirements/quality.txt
     #   fs-s3fs
-botocore==1.29.72
+botocore==1.29.74
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -205,9 +205,9 @@ openedx-django-pyfs==3.2.1
     # via
     #   -r requirements/quality.txt
     #   xblock
-openedx_events @ git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba
+openedx-events==5.1.0
     # via -r requirements/quality.txt
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
+openedx-filters==1.1.0
     # via -r requirements/quality.txt
 packaging==23.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.12.13
+astroid==2.14.2
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -34,16 +34,16 @@ boto==2.49.0
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
-boto3==1.26.40
+boto3==1.26.72
     # via
     #   -r requirements/quality.txt
     #   fs-s3fs
-botocore==1.29.40
+botocore==1.29.72
     # via
     #   -r requirements/quality.txt
     #   boto3
     #   s3transfer
-build==0.9.0
+build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -57,7 +57,7 @@ chardet==5.1.0
     #   -r requirements/quality.txt
     #   binaryornot
     #   diff-cover
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -85,13 +85,13 @@ cookiecutter==2.1.1
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
-coverage[toml]==7.0.1
+coverage[toml]==7.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-diff-cover==7.3.0
+diff-cover==7.4.0
     # via -r requirements/dev.in
 dill==0.3.6
     # via
@@ -101,28 +101,24 @@ distlib==0.3.6
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   django-model-utils
-    #   django-pyfs
     #   djangorestframework
     #   edx-i18n-tools
+    #   openedx-django-pyfs
     #   openedx-events
     #   openedx-filters
     #   xblock-sdk
 django-model-utils==4.3.1
     # via -r requirements/quality.txt
-django-pyfs==3.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   xblock-sdk
 djangorestframework==3.14.0
     # via -r requirements/quality.txt
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
-edx-lint==5.3.0
+edx-lint==5.3.2
     # via -r requirements/quality.txt
 edx-opaque-keys[django]==2.3.0
     # via
@@ -132,7 +128,7 @@ exceptiongroup==1.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-fastavro==1.7.0
+fastavro==1.7.1
     # via
     #   -r requirements/quality.txt
     #   openedx-events
@@ -144,24 +140,24 @@ filelock==3.9.0
 fs==2.4.16
     # via
     #   -r requirements/quality.txt
-    #   django-pyfs
     #   fs-s3fs
+    #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
     #   -r requirements/quality.txt
-    #   django-pyfs
+    #   openedx-django-pyfs
     #   xblock-sdk
 idna==3.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-isort==5.11.4
+isort==5.12.0
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -184,8 +180,8 @@ jmespath==1.0.1
 lazy==1.5
     # via
     #   -r requirements/quality.txt
-    #   xblock-sdk
-lazy-object-proxy==1.8.0
+    #   xblock
+lazy-object-proxy==1.9.0
     # via
     #   -r requirements/quality.txt
     #   astroid
@@ -194,7 +190,7 @@ lxml==4.9.2
     #   -r requirements/quality.txt
     #   xblock
     #   xblock-sdk
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -r requirements/quality.txt
     #   jinja2
@@ -203,13 +199,17 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-mock==5.0.0
+mock==5.0.1
     # via -r requirements/quality.txt
+openedx-django-pyfs==3.2.1
+    # via
+    #   -r requirements/quality.txt
+    #   xblock
 openedx_events @ git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba
     # via -r requirements/quality.txt
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@d0206cf84f2e5e22b1a99d06566d88839d40b9fe
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
     # via -r requirements/quality.txt
-packaging==22.0
+packaging==23.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -219,17 +219,13 @@ packaging==22.0
     #   tox
 path==16.6.0
     # via edx-i18n-tools
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pep517==0.13.0
-    # via
-    #   -r requirements/pip-tools.txt
-    #   build
-pip-tools==6.12.1
+pip-tools==6.12.2
     # via -r requirements/pip-tools.txt
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -250,11 +246,11 @@ py==1.11.0
     #   tox
 pycodestyle==2.10.0
     # via -r requirements/quality.txt
-pydocstyle==6.1.1
+pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.13.0
+pygments==2.14.0
     # via diff-cover
-pylint==2.15.9
+pylint==2.16.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -282,7 +278,11 @@ pypng==0.20220715.0
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
-pytest==7.2.0
+pyproject-hooks==1.0.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   build
+pytest==7.2.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -297,12 +297,12 @@ python-dateutil==2.8.2
     #   arrow
     #   botocore
     #   xblock
-python-slugify==7.0.0
+python-slugify==8.0.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
     #   cookiecutter
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/quality.txt
     #   django
@@ -315,7 +315,7 @@ pyyaml==6.0
     #   cookiecutter
     #   edx-i18n-tools
     #   xblock
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -326,7 +326,7 @@ s3transfer==0.6.0
     # via
     #   -r requirements/quality.txt
     #   boto3
-simplejson==3.18.0
+simplejson==3.18.3
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
@@ -347,7 +347,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/quality.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -363,8 +363,8 @@ tomli==2.0.1
     #   -r requirements/quality.txt
     #   build
     #   coverage
-    #   pep517
     #   pylint
+    #   pyproject-hooks
     #   pytest
     #   tox
 tomlkit==0.11.6
@@ -378,18 +378,18 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.txt
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   botocore
     #   requests
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -411,11 +411,11 @@ wrapt==1.14.1
     # via
     #   -r requirements/quality.txt
     #   astroid
-xblock==1.6.1
+xblock[django]==1.6.2
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
-xblock-sdk==0.5.1
+xblock-sdk==0.5.4
     # via -r requirements/quality.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -35,11 +35,11 @@ boto==2.49.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-boto3==1.26.72
+boto3==1.26.74
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.29.72
+botocore==1.29.74
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -133,7 +133,7 @@ importlib-metadata==6.0.0
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==5.10.2
+importlib-resources==5.12.0
     # via keyring
 iniconfig==2.0.0
     # via
@@ -189,9 +189,9 @@ openedx-django-pyfs==3.2.1
     # via
     #   -r requirements/test.txt
     #   xblock
-openedx_events @ git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba
+openedx-events==5.1.0
     # via -r requirements/test.txt
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
+openedx-filters==1.1.0
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -363,7 +363,7 @@ xblock[django]==1.6.2
     #   xblock-sdk
 xblock-sdk==0.5.4
     # via -r requirements/test.txt
-zipp==3.13.0
+zipp==3.14.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
 appdirs==1.4.4
     # via
@@ -29,22 +29,22 @@ binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-bleach==5.0.1
+bleach==6.0.0
     # via readme-renderer
 boto==2.49.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-boto3==1.26.40
+boto3==1.26.72
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.29.40
+botocore==1.29.72
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-build==0.9.0
+build==0.10.0
     # via -r requirements/doc.in
 certifi==2022.12.7
     # via
@@ -56,7 +56,7 @@ chardet==5.1.0
     # via
     #   -r requirements/test.txt
     #   binaryornot
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   -r requirements/test.txt
     #   requests
@@ -67,34 +67,28 @@ click==8.1.3
     #   cookiecutter
 code-annotations==1.3.0
     # via -r requirements/test.txt
-commonmark==0.9.1
-    # via rich
 cookiecutter==2.1.1
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.0.1
+coverage[toml]==7.1.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==38.0.4
+cryptography==39.0.1
     # via secretstorage
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-model-utils
-    #   django-pyfs
     #   djangorestframework
+    #   openedx-django-pyfs
     #   openedx-events
     #   openedx-filters
     #   xblock-sdk
 django-model-utils==4.3.1
     # via -r requirements/test.txt
-django-pyfs==3.2.0
-    # via
-    #   -r requirements/test.txt
-    #   xblock-sdk
 djangorestframework==3.14.0
     # via -r requirements/test.txt
 doc8==1.1.1
@@ -113,20 +107,20 @@ exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-fastavro==1.7.0
+fastavro==1.7.1
     # via
     #   -r requirements/test.txt
     #   openedx-events
 fs==2.4.16
     # via
     #   -r requirements/test.txt
-    #   django-pyfs
     #   fs-s3fs
+    #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
     #   -r requirements/test.txt
-    #   django-pyfs
+    #   openedx-django-pyfs
     #   xblock-sdk
 idna==3.4
     # via
@@ -134,14 +128,14 @@ idna==3.4
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.2.0
+importlib-metadata==6.0.0
     # via
     #   keyring
     #   sphinx
     #   twine
 importlib-resources==5.10.2
     # via keyring
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -172,38 +166,44 @@ keyring==23.13.1
 lazy==1.5
     # via
     #   -r requirements/test.txt
-    #   xblock-sdk
+    #   xblock
 lxml==4.9.2
     # via
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-markupsafe==2.1.1
+markdown-it-py==2.1.0
+    # via rich
+markupsafe==2.1.2
     # via
     #   -r requirements/test.txt
     #   jinja2
     #   xblock
-mock==5.0.0
+mdurl==0.1.2
+    # via markdown-it-py
+mock==5.0.1
     # via -r requirements/test.txt
 more-itertools==9.0.0
     # via jaraco-classes
+openedx-django-pyfs==3.2.1
+    # via
+    #   -r requirements/test.txt
+    #   xblock
 openedx_events @ git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba
     # via -r requirements/test.txt
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@d0206cf84f2e5e22b1a99d06566d88839d40b9fe
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
     # via -r requirements/test.txt
-packaging==22.0
+packaging==23.0
     # via
     #   -r requirements/test.txt
     #   build
     #   pytest
     #   sphinx
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pep517==0.13.0
-    # via build
-pkginfo==1.9.2
+pkginfo==1.9.6
     # via twine
 pluggy==1.0.0
     # via
@@ -211,7 +211,7 @@ pluggy==1.0.0
     #   pytest
 pycparser==2.21
     # via cffi
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   doc8
     #   readme-renderer
@@ -225,7 +225,9 @@ pypng==0.20220715.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-pytest==7.2.0
+pyproject-hooks==1.0.0
+    # via build
+pytest==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -240,12 +242,12 @@ python-dateutil==2.8.2
     #   arrow
     #   botocore
     #   xblock
-python-slugify==7.0.0
+python-slugify==8.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/test.txt
     #   babel
@@ -260,7 +262,7 @@ pyyaml==6.0
     #   xblock
 readme-renderer==37.3
     # via twine
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/test.txt
     #   cookiecutter
@@ -274,7 +276,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==12.6.0
+rich==13.3.1
     # via twine
 s3transfer==0.6.0
     # via
@@ -282,7 +284,7 @@ s3transfer==0.6.0
     #   boto3
 secretstorage==3.3.3
     # via keyring
-simplejson==3.18.0
+simplejson==3.18.3
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
@@ -295,13 +297,15 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.0.0
-    # via -r requirements/doc.in
-sphinxcontrib-applehelp==1.0.2
+sphinx==5.3.0
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/doc.in
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -313,7 +317,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -329,13 +333,13 @@ tomli==2.0.1
     #   build
     #   coverage
     #   doc8
-    #   pep517
+    #   pyproject-hooks
     #   pytest
 twine==4.0.2
     # via -r requirements/doc.in
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via rich
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -r requirements/test.txt
     #   botocore
@@ -353,13 +357,13 @@ webob==1.8.7
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-xblock==1.6.1
+xblock[django]==1.6.2
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-xblock-sdk==0.5.1
+xblock-sdk==0.5.4
     # via -r requirements/test.txt
-zipp==3.11.0
+zipp==3.13.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,20 +4,18 @@
 #
 #    make upgrade
 #
-build==0.9.0
+build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==22.0
+packaging==23.0
     # via build
-pep517==0.13.0
-    # via build
-pip-tools==6.12.1
+pip-tools==6.12.2
     # via -r requirements/pip-tools.in
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
-    # via
-    #   build
-    #   pep517
+    # via build
 wheel==0.38.4
     # via pip-tools
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,9 +4,11 @@
 #
 #    make upgrade
 #
-pip==23.0
+wheel==0.38.4
+    # via -r requirements/pip.in
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==23.0.1
     # via -r requirements/pip.in
 setuptools==67.3.2
-    # via -r requirements/pip.in
-wheel==0.38.4
     # via -r requirements/pip.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,9 @@
 #
 #    make upgrade
 #
-pip==22.3.1
+pip==23.0
     # via -r requirements/pip.in
-setuptools==59.8.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/pip.in
+setuptools==67.3.2
+    # via -r requirements/pip.in
 wheel==0.38.4
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -33,11 +33,11 @@ boto==2.49.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-boto3==1.26.72
+boto3==1.26.74
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.29.72
+botocore==1.29.74
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -167,9 +167,9 @@ openedx-django-pyfs==3.2.1
     # via
     #   -r requirements/test.txt
     #   xblock
-openedx_events @ git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba
+openedx-events==5.1.0
     # via -r requirements/test.txt
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
+openedx-filters==1.1.0
     # via -r requirements/test.txt
 packaging==23.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,7 +16,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.12.13
+astroid==2.14.2
     # via
     #   pylint
     #   pylint-celery
@@ -33,11 +33,11 @@ boto==2.49.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-boto3==1.26.40
+boto3==1.26.72
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.29.40
+botocore==1.29.72
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -50,7 +50,7 @@ chardet==5.1.0
     # via
     #   -r requirements/test.txt
     #   binaryornot
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   -r requirements/test.txt
     #   requests
@@ -71,31 +71,27 @@ cookiecutter==2.1.1
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.0.1
+coverage[toml]==7.1.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 dill==0.3.6
     # via pylint
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-model-utils
-    #   django-pyfs
     #   djangorestframework
+    #   openedx-django-pyfs
     #   openedx-events
     #   openedx-filters
     #   xblock-sdk
 django-model-utils==4.3.1
     # via -r requirements/test.txt
-django-pyfs==3.2.0
-    # via
-    #   -r requirements/test.txt
-    #   xblock-sdk
 djangorestframework==3.14.0
     # via -r requirements/test.txt
-edx-lint==5.3.0
+edx-lint==5.3.2
     # via -r requirements/quality.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -105,30 +101,30 @@ exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-fastavro==1.7.0
+fastavro==1.7.1
     # via
     #   -r requirements/test.txt
     #   openedx-events
 fs==2.4.16
     # via
     #   -r requirements/test.txt
-    #   django-pyfs
     #   fs-s3fs
+    #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
     #   -r requirements/test.txt
-    #   django-pyfs
+    #   openedx-django-pyfs
     #   xblock-sdk
 idna==3.4
     # via
     #   -r requirements/test.txt
     #   requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.11.4
+isort==5.12.0
     # via
     #   -r requirements/quality.in
     #   pylint
@@ -150,36 +146,40 @@ jmespath==1.0.1
 lazy==1.5
     # via
     #   -r requirements/test.txt
-    #   xblock-sdk
-lazy-object-proxy==1.8.0
+    #   xblock
+lazy-object-proxy==1.9.0
     # via astroid
 lxml==4.9.2
     # via
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -r requirements/test.txt
     #   jinja2
     #   xblock
 mccabe==0.7.0
     # via pylint
-mock==5.0.0
+mock==5.0.1
     # via -r requirements/test.txt
+openedx-django-pyfs==3.2.1
+    # via
+    #   -r requirements/test.txt
+    #   xblock
 openedx_events @ git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba
     # via -r requirements/test.txt
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@d0206cf84f2e5e22b1a99d06566d88839d40b9fe
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
     # via -r requirements/test.txt
-packaging==22.0
+packaging==23.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -187,9 +187,9 @@ pluggy==1.0.0
     #   pytest
 pycodestyle==2.10.0
     # via -r requirements/quality.in
-pydocstyle==6.1.1
+pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.15.9
+pylint==2.16.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -211,7 +211,7 @@ pypng==0.20220715.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -226,12 +226,12 @@ python-dateutil==2.8.2
     #   arrow
     #   botocore
     #   xblock
-python-slugify==7.0.0
+python-slugify==8.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/test.txt
     #   django
@@ -243,7 +243,7 @@ pyyaml==6.0
     #   code-annotations
     #   cookiecutter
     #   xblock
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/test.txt
     #   cookiecutter
@@ -252,7 +252,7 @@ s3transfer==0.6.0
     # via
     #   -r requirements/test.txt
     #   boto3
-simplejson==3.18.0
+simplejson==3.18.3
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
@@ -269,7 +269,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -286,11 +286,11 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.11.6
     # via pylint
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -r requirements/test.txt
     #   botocore
@@ -307,11 +307,11 @@ webob==1.8.7
     #   xblock-sdk
 wrapt==1.14.1
     # via astroid
-xblock==1.6.1
+xblock[django]==1.6.2
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-xblock-sdk==0.5.1
+xblock-sdk==0.5.4
     # via -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,9 +21,9 @@ binaryornot==0.4.4
     # via cookiecutter
 boto==2.49.0
     # via xblock-sdk
-boto3==1.26.72
+boto3==1.26.74
     # via fs-s3fs
-botocore==1.29.72
+botocore==1.29.74
     # via
     #   boto3
     #   s3transfer
@@ -104,9 +104,9 @@ mock==5.0.1
     # via -r requirements/test.in
 openedx-django-pyfs==3.2.1
     # via xblock
-openedx_events @ git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba
+openedx-events==5.1.0
     # via -r requirements/base.txt
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
+openedx-filters==1.1.0
     # via -r requirements/base.txt
 packaging==23.0
     # via pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,9 +21,9 @@ binaryornot==0.4.4
     # via cookiecutter
 boto==2.49.0
     # via xblock-sdk
-boto3==1.26.40
+boto3==1.26.72
     # via fs-s3fs
-botocore==1.29.40
+botocore==1.29.72
     # via
     #   boto3
     #   s3transfer
@@ -31,7 +31,7 @@ certifi==2022.12.7
     # via requests
 chardet==5.1.0
     # via binaryornot
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -41,21 +41,19 @@ code-annotations==1.3.0
     # via -r requirements/test.in
 cookiecutter==2.1.1
     # via xblock-sdk
-coverage[toml]==7.0.1
+coverage[toml]==7.1.0
     # via pytest-cov
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   django-model-utils
-    #   django-pyfs
     #   djangorestframework
+    #   openedx-django-pyfs
     #   openedx-events
     #   openedx-filters
     #   xblock-sdk
 django-model-utils==4.3.1
     # via -r requirements/base.txt
-django-pyfs==3.2.0
-    # via xblock-sdk
 djangorestframework==3.14.0
     # via -r requirements/test.in
 edx-opaque-keys[django]==2.3.0
@@ -64,22 +62,22 @@ edx-opaque-keys[django]==2.3.0
     #   openedx-events
 exceptiongroup==1.1.0
     # via pytest
-fastavro==1.7.0
+fastavro==1.7.1
     # via
     #   -r requirements/base.txt
     #   openedx-events
 fs==2.4.16
     # via
-    #   django-pyfs
     #   fs-s3fs
+    #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
-    #   django-pyfs
+    #   openedx-django-pyfs
     #   xblock-sdk
 idna==3.4
     # via requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
     # via
@@ -93,24 +91,26 @@ jmespath==1.0.1
     #   boto3
     #   botocore
 lazy==1.5
-    # via xblock-sdk
+    # via xblock
 lxml==4.9.2
     # via
     #   xblock
     #   xblock-sdk
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   jinja2
     #   xblock
-mock==5.0.0
+mock==5.0.1
     # via -r requirements/test.in
+openedx-django-pyfs==3.2.1
+    # via xblock
 openedx_events @ git+https://github.com/open-craft/openedx-events.git@77ad965c4ac5157b861a19b8cb6b9240883008ba
     # via -r requirements/base.txt
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@d0206cf84f2e5e22b1a99d06566d88839d40b9fe
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
     # via -r requirements/base.txt
-packaging==22.0
+packaging==23.0
     # via pytest
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -122,7 +122,7 @@ pymongo==3.13.0
     #   edx-opaque-keys
 pypng==0.20220715.0
     # via xblock-sdk
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -135,11 +135,11 @@ python-dateutil==2.8.2
     #   arrow
     #   botocore
     #   xblock
-python-slugify==7.0.0
+python-slugify==8.0.0
     # via
     #   code-annotations
     #   cookiecutter
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/base.txt
     #   django
@@ -150,13 +150,13 @@ pyyaml==6.0
     #   code-annotations
     #   cookiecutter
     #   xblock
-requests==2.28.1
+requests==2.28.2
     # via
     #   cookiecutter
     #   xblock-sdk
 s3transfer==0.6.0
     # via boto3
-simplejson==3.18.0
+simplejson==3.18.3
     # via xblock-sdk
 six==1.16.0
     # via
@@ -167,7 +167,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -178,7 +178,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   botocore
     #   requests
@@ -190,9 +190,9 @@ webob==1.8.7
     # via
     #   xblock
     #   xblock-sdk
-xblock==1.6.1
+xblock[django]==1.6.2
     # via xblock-sdk
-xblock-sdk==0.5.1
+xblock-sdk==0.5.4
     # via -r requirements/test.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/skill_tagging/skill_tagging_mixin.py
+++ b/skill_tagging/skill_tagging_mixin.py
@@ -7,6 +7,7 @@ import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
+from django.utils.timezone import datetime, timezone
 from django.utils.translation import gettext as _
 from openedx_events.learning.data import XBlockSkillVerificationData
 from openedx_events.learning.signals import XBLOCK_SKILL_VERIFIED
@@ -100,6 +101,7 @@ class SkillTaggingMixin:
         usage_key = str(self.scope_ids.usage_id)
         if not self.has_verified_tags and (verified_skills or ignored_skills):
             XBLOCK_SKILL_VERIFIED.send_event(
+                time=datetime.now(timezone.utc),
                 xblock_info=XBlockSkillVerificationData(
                     usage_key=usage_key,
                     verified_skills=verified_skills,

--- a/skill_tagging/static/tagging.css
+++ b/skill_tagging/static/tagging.css
@@ -40,7 +40,7 @@
     font-weight: 700;
     font-size: 32px;
     line-height: 28px;
-    margin-bottom: 20px;
+    margin-bottom: 20px !important;
 }
 
 .tag-verification-vertical button {
@@ -51,6 +51,8 @@
 .tag-verification-video button {
     background: white;
     color: #00262B;
+    width: fit-content;
+    align-self: center;
 }
 
 .tag-verification-container button {
@@ -61,8 +63,14 @@
     box-shadow: none;
 }
 
+.tag-verification-video .tag-verification-form-container {
+    display: flex;
+    flex-direction: column;
+}
+
 .tag-verification-video p {
     width: 465px;
+    align-self: center;
 }
 
 .tag-verification-vertical button:hover, .tag-verification-vertical button:focus {
@@ -104,6 +112,7 @@
     font-weight: 400;
     font-size: 12px;
     line-height: 24px;
+    margin-bottom: 0px;
 }
 
 .tag-verification-vertical .tag-verification-chip {
@@ -123,7 +132,7 @@
 }
 
 .tag-verification-video .tag-verification-chip.tag-verification-chip-hover:hover {
-    background: #065683;
+    background: #576D71;
 }
 
 .tag-verification-chip-clickable {
@@ -152,7 +161,7 @@
 }
 
 .tag-verification-video .tag-verification-tags-container input[type=checkbox]:focus + label {
-    background: #065683;
+    background: #576D71;
 }
 
 .tag-verification-none-selected-container {
@@ -181,6 +190,7 @@
     padding-left: 40px;
     position: relative;
 }
+
 .tag-verification-container button.loading:before {
     content: "";
     position: absolute;
@@ -190,11 +200,19 @@
     width: 0px;
     height: 0px;
     margin-top: -2px;
-    border: 2px solid rgba(255,255,255,0.5);
-    border-left-color: #FFF;
-    border-top-color: #FFF;
     animation: spin .6s infinite linear, grow .3s forwards ease-out;
 }
+
+.tag-verification-vertical button.loading:before {
+    border: 2px solid rgba(255,255,255,0.5);
+    border-top-color: #FFF;
+}
+
+.tag-verification-video button.loading:before {
+    border: 2px solid rgba(0,0,0,1);
+    border-top-color: #FFF;
+}
+
 @keyframes spin {
     to {
         transform: rotate(359deg);
@@ -207,4 +225,8 @@
         margin-top: -8px;
         right: 13px;
     }
+}
+
+.tag-verification-container button[disabled] {
+    opacity: 0.3;
 }

--- a/skill_tagging/static/tagging.css
+++ b/skill_tagging/static/tagging.css
@@ -93,6 +93,11 @@
     font-size: 18px;
     line-height: 28px;
 }
+
+.tag-verification-vertical p {
+    color: #454545;
+}
+
 .tag-verification-tags-container {
     flex-direction: row;
     align-items: center;

--- a/skill_tagging/static/tagging.js
+++ b/skill_tagging/static/tagging.js
@@ -86,15 +86,22 @@ function tagVerificationVerifyTags(source, url, blockId) {
     });
 }
 
+window.tagVerificationSelectionHistoryObject = window.tagVerificationSelectionHistoryObject || {};
+
 function tagVerificationOnNoneCheckboxClick(source, blockId) {
-  tagVerificationToggleSubmitButton(blockId);
-  if (!source.checked) {
-    return;
-  }
   checkboxes = document.getElementsByName(`tag-verification-skills-${blockId}`);
-  for (var i = 0, n = checkboxes.length; i < n; i++) {
-    checkboxes[i].checked = false;
+  if (source.checked) {
+    window.tagVerificationSelectionHistoryObject[blockId] = {};
+    for (var i = 0, n = checkboxes.length; i < n; i++) {
+      window.tagVerificationSelectionHistoryObject[blockId][checkboxes[i].id] = checkboxes[i].checked;
+      checkboxes[i].checked = false;
+    }
+  } else {
+    for (var i = 0, n = checkboxes.length; i < n; i++) {
+      checkboxes[i].checked = window.tagVerificationSelectionHistoryObject[blockId][checkboxes[i].id];
+    }
   }
+  tagVerificationToggleSubmitButton(blockId);
 }
 
 function tagVerificationRetry(blockId) {


### PR DESCRIPTION
**Description:** The verification form for videos and units have been implemented in https://github.com/open-craft/xblock-skill-tagging/pull/4 according to [this design](https://www.figma.com/file/SDyZUSWHSfUGQCM3YuOoC8/Skills-Tagging?node-id=0%3A1&t=zD3NPz1CZgrKGrvI-1). This MR adds few styling and UX tweaks that would improve the student's user experience.

Also updates `openedx-filters` and `openedx_events` dependencies.

**JIRA:** `Private-token`: https://tasks.opencraft.com/browse/BB-7123

**Testing instructions:**

- [Sandbox URL](https://app.skilltagging.opencraft.hosting/learning/course/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@sequential+block@19a30717eff543078a5d94ae9d6c18a5/block-v1:edX+DemoX+Demo_Course+type@vertical+block@4f6c1b4e316a419ab5b6bf30e6c708e9)
- Scroll to bottom to see vertical verification form
- Skip video to end to see video tags verification form

**Reviewers:**
- [ ] @ali-hugo

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
