### PR TITLE
Include repo in upcoming releases

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -17,5 +17,4 @@ openedx-release:
     # The openedx-release key is described in OEP-10:
     #   https://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
     # The FAQ might also be helpful: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1331268879/Open+edX+Release+FAQ
-    maybe: true   # Delete this "maybe" line when you have decided about Open edX inclusion.
     ref: main


### PR DESCRIPTION
Remove the `maybe: true` placeholder from `openedx.yaml` file so that this repo will be tagged for upcoming Open edX releases.