### PR TITLE
feat: add temporary option to configure openedx event topic name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Unreleased
 
 *
 
+[0.1.1] - 2023-06-14
+************************************************
+
+Added
+=====
+
+* Add temporary option to configure topic name for skill-verified event.
+
 [0.1.0] - 2022-12-01
 ************************************************
 

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ has detailed information on setting up event bus. The host would be
 ``edx-platform`` while ``course-discovery`` will be the consumer for the event
 bus.
 
-.. _emits: https://github.com/openedx/xblock-skill-tagging/blob/b323d8b13b66a69326b8fad77ccba4631dbdece9/skill_tagging/skill_tagging_mixin.py#L103
+.. _emits: https://github.com/openedx/xblock-skill-tagging/blob/main/skill_tagging/handlers.py
 .. _event_bus_kafka: https://github.com/openedx/event-bus-kafka
 .. _event_bus_redis: https://github.com/openedx/event-bus-redis
 .. _How to start using the Event Bus: https://openedx.atlassian.net/wiki/spaces/AC/pages/3508699151/How+to+start+using+the+Event+Bus
@@ -105,6 +105,8 @@ settings: ``lms/envs/common.py``
    # helps to configure probability of displaying the verification forms. Values in range 0 to 1 are allowed, where 0
    # means never and 1 means always display. Default value is 0.5 i.e. 50% chance of displaying the form.
    SHOW_SKILL_VERIFICATION_PROBABILITY = 0.5
+   # Optionally update topic name for verification event emitted when a user verifies tags for an xblock.
+   EVENT_BUS_XBLOCK_VERIFICATION_TOPIC = "learning-custom-xblock-skill-verfied"
 
 
 Developing

--- a/skill_tagging/__init__.py
+++ b/skill_tagging/__init__.py
@@ -2,7 +2,7 @@
 Django app plugin for fetching and verifying tags for xblock skills.
 """
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 # pylint: disable=invalid-name
 default_app_config = 'skill_tagging.apps.SkillTaggingConfig'

--- a/skill_tagging/handlers.py
+++ b/skill_tagging/handlers.py
@@ -2,6 +2,7 @@
 skill_tagging signal handlers
 """
 
+from django.conf import settings
 from openedx_events.event_bus import get_producer
 from openedx_events.learning.signals import XBLOCK_SKILL_VERIFIED
 
@@ -10,9 +11,10 @@ def listen_for_xblock_skill_verified(**kwargs):
     """
     Publish openedx-event XBLOCK_SKILL_VERIFIED signal onto the event bus.
     """
+    topic = getattr(settings, "EVENT_BUS_XBLOCK_VERIFICATION_TOPIC", "learning-xblock-skill-verified")
     get_producer().send(
         signal=XBLOCK_SKILL_VERIFIED,
-        topic='xblock-skill-verified',
+        topic=topic,
         event_key_field='xblock_info.usage_key',
         event_data={'xblock_info': kwargs['xblock_info']},
         event_metadata=kwargs['metadata'],


### PR DESCRIPTION
**Description:** A temporary setting to configure topic name for skill-verified openedx event. This will be removed once the decision in https://github.com/openedx/openedx-events/pull/224 is approved and implemented.

`Private-ref`: [BB-7555](https://tasks.opencraft.com/browse/BB-7555)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
