### PR TITLE
fix: add tox 4 support

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,11 +5,15 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.8
   install:
     - requirements: requirements/doc.txt

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -3,4 +3,3 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -26,8 +26,5 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
-    #   tox-battery
-tox-battery==0.6.1
-    # via -r requirements/ci.in
 virtualenv==20.23.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -361,9 +361,6 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.1
-    # via -r requirements/ci.txt
 typing-extensions==4.6.3
     # via
     #   -r requirements/quality.txt

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ addopts = --cov skill_tagging --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements site-packages
 
 [testenv]
-whitelist_externals =
+allowlist_externals =
     make
 
 deps =
@@ -33,7 +33,7 @@ commands =
 
 
 [testenv:quality]
-whitelist_externals =
+allowlist_externals =
     make
     rm
     touch


### PR DESCRIPTION
## Description
- Updated tox config to add support for tox 4
- Updated `.readthedocs.yml` config to fix the failing docs build
- Removed `tox-battery` from requirements to allow tox>4 upgrade