### PR TITLE
chore: update Django to 3.2.23 for Quince - Security Patch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ asgiref==3.7.2
     # via django
 attrs==23.1.0
     # via openedx-events
-django==3.2.19
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -90,7 +90,7 @@ distlib==0.3.6
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.19
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -72,7 +72,7 @@ coverage[toml]==7.2.7
     #   pytest-cov
 cryptography==41.0.1
     # via secretstorage
-django==3.2.19
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -72,7 +72,7 @@ coverage[toml]==7.2.7
     #   pytest-cov
 dill==0.3.6
     # via pylint
-django==3.2.19
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description
This PR updates Django to version 3.2.23 in the Quince release branch. The update includes the latest security patch, as part of the BTR working group's ongoing efforts to ensure the security of Open edX's supported named releases.

For more information, see: [https://github.com/openedx/wg-build-test-release/issues/324](https://github.com/openedx/wg-build-test-release/issues/324)