### PR TITLE
Replace django.utils.timezone.utc with datetime.timezone.utc 

### DIFF
--- a/skill_tagging/skill_tagging_mixin.py
+++ b/skill_tagging/skill_tagging_mixin.py
@@ -3,8 +3,8 @@ A mixin that fetches and verifies skills related to an Xblock,
 that can be added for all XBlocks.
 """
 
-from datetime import timezone
 import logging
+from datetime import timezone
 from urllib.parse import urljoin
 
 from django.conf import settings

--- a/skill_tagging/skill_tagging_mixin.py
+++ b/skill_tagging/skill_tagging_mixin.py
@@ -3,11 +3,12 @@ A mixin that fetches and verifies skills related to an Xblock,
 that can be added for all XBlocks.
 """
 
+from datetime import timezone
 import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
-from django.utils.timezone import datetime, timezone
+from django.utils.timezone import datetime
 from django.utils.translation import gettext as _
 from openedx_events.learning.data import XBlockSkillVerificationData
 from openedx_events.learning.signals import XBLOCK_SKILL_VERIFIED


### PR DESCRIPTION
Resolves https://github.com/openedx/public-engineering/issues/356

### Description
This PR addresses compatibility with Django 5.0 and above.

In Django 5.0, django.utils.timezone.utc has been removed as noted in the official release notes. To ensure forward compatibility—particularly with the upcoming upgrade to Django 5.2—this PR replaces usage of timezone.utc with `datetime.timezone.utc` from Python’s standard library.

This change prevents `AttributeError` and ensures the codebase remains compatible with newer versions of Django.

Release Notes Link:
https://docs.djangoproject.com/en/5.2/releases/5.0/#:~:text=django.utils.timezone.utc

Reference PR: https://github.com/rq/django-rq/issues/610
Since django.utils.timezone.utc was merely an alias and has been removed in Django 5.0, replacing it with datetime.timezone.utc from the standard library is the recommended and compatible approach.